### PR TITLE
Fix Broken pipe errors

### DIFF
--- a/src/main/java/io/binx/cfnlint/plugin/utils/CheckRunner.java
+++ b/src/main/java/io/binx/cfnlint/plugin/utils/CheckRunner.java
@@ -34,9 +34,14 @@ public final class CheckRunner {
         CheckResult result;
         try {
             File path = new File(new File(cwd), file);
-            GeneralCommandLine commandLine = createCommandLine(exe, cwd)
-                    .withInput(content)
-                    .withParameters("-f", "json", "-t", file);
+            GeneralCommandLine commandLine = createCommandLine(exe, cwd);
+            if (content == null) {
+                commandLine = commandLine.withParameters("-f", "json", "-t", file);
+            } else {
+                commandLine = ((CommandLineWithInput) commandLine)
+                        .withInput(content)
+                        .withParameters("-f", "json", "-t", "-");
+            }
             ProcessOutput out = execute(commandLine);
             try {
                 result = new CheckResult(parse(out.getStdout()), out.getStderr());

--- a/src/main/java/io/binx/cfnlint/plugin/utils/CommandLineWithInput.java
+++ b/src/main/java/io/binx/cfnlint/plugin/utils/CommandLineWithInput.java
@@ -1,6 +1,5 @@
 package io.binx.cfnlint.plugin.utils;
 
-import com.google.common.io.CharSource;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +23,7 @@ public class CommandLineWithInput extends GeneralCommandLine {
         Process process = super.createProcess();
         if (input != null) {
             try (OutputStream stdin = process.getOutputStream()) {
-                CharSource.wrap(input).asByteSource(StandardCharsets.UTF_8).copyTo(stdin);
+                stdin.write(input.getBytes(StandardCharsets.UTF_8));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
This patch fixes the broken pipe errors (#4).

The broken pipe error was triggered by streaming big files with guava api, considering our usage here we can use directly plain java.
Moreover the input was never used because the file name to analyze was always passed as a command line parameter. Now we are either passing the filename or '-' to use the sdin.