### PR TITLE
support for 2019.3, update intellij to 0.4.13, add change note

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.4.13'
+    id 'org.jetbrains.intellij' version '0.4.14'
     id 'io.freefair.git-version' version '2.5.9'
 }
 
@@ -19,11 +19,12 @@ dependencies {
 }
 
 intellij {
-    version '2019.2'
+    version '2019.3'
 }
 
 patchPluginXml {
     changeNotes """
+       <p>0.1.8 support IntelliJ 2019.3</p>
        <p>0.1.7 support IntelliJ 2019.2</p>
        <p>0.1.6 fix Broken pipe errors by Philippe Jandot</p>
        <p>0.1.5 official build for 2019.1</p>


### PR DESCRIPTION
I had a warning in Webstorm 2019.3 that the plugin was incompatible. So i thought i will change the configuration to make it compatible.

## Changes
- Changed the org.jetbrains.intellij plugin from 0.4.12 to 0.4.13
- Updated the intelij version from 2019.2 to 2019.3
- Added change note stating the changes

## System
```
  Gradle: 5.2.1
  Java: 12.0.1 2019-04-16
  cfn-lint: 0.25.7
  Operating system: OSX 10.15.1
```

## Test case
- Build a jar with gradle
- Installed the plugin from disk in Webstorm 2019.3
- Reloaded Webstorm
- Open a cloudformation template
- Wrote some wrong cloudformation statements 🙈 
- Notices red lines 
- Go to the other settings options
- Change settings to tread all issues as warnings to be ticked
- Change settings to highlight whole line to be ticked
- Go to the cloudformation template
- Notice whole line to be marked as warning
