### PR TITLE
intellij version LATEST-EAP-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 }
 
 intellij {
-    version '2019.3'
+    version 'LATEST-EAP-SNAPSHOT'
 }
 
 patchPluginXml {


### PR DESCRIPTION
https://github.com/binxio/cfn-lint-plugin/issues/11

[2018.2](https://github.com/binxio/cfn-lint-plugin/commit/0320e887c1d7be4d57ab21517885de89433e3fca)
[2018.3](https://github.com/binxio/cfn-lint-plugin/commit/14d3c89a24882f7a8fb933ab817d7777aa7b76ef)
[2019.1](https://github.com/binxio/cfn-lint-plugin/commit/08998d4a2d6d9e13d502bdaeffdfbe2b6a279b3b)
[2019.2](https://github.com/binxio/cfn-lint-plugin/pull/8/commits/205de58c4de0a55bd5a07d0cf829273580c7d681)
[2019.3](https://github.com/binxio/cfn-lint-plugin/commit/46815433422bfda06e7c23580a298d658d93f792)
[2020.1](https://github.com/binxio/cfn-lint-plugin/commit/2da61c7aa619dd61b0db60d6fd5127890d1e62ba)

---

@mvanholsteijn Haven't tested yet but wanted to start the discussion on how to support [2020.1](https://blog.jetbrains.com/idea/tag/intellij-idea-2020-1/) and beyond because most of the previous commits look like they just needed the latest intellij version and [`'LATEST-EAP-SNAPSHOT'` is the default value for intellij version](https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties) 
