### PR TITLE
Support 2021.1 for real

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.4.22'
+    id 'org.jetbrains.intellij' version '0.7.2'
     id 'io.freefair.git-version' version '4.1.6'
 }
 
@@ -19,11 +19,12 @@ dependencies {
 }
 
 intellij {
-    version '2020.2.4'
+    version '2021.1'
 }
 
 patchPluginXml {
     changeNotes """
+       <p>0.1.19 support IntelliJ 2021.1</p>
        <p>0.1.18 support IntelliJ 2020.2.4</p>
        <p>0.1.17 support IntelliJ 2020.3</p>
        <p>0.1.16 support IntelliJ 2020.2.2</p>

--- a/src/main/java/io/binx/cfnlint/plugin/CheckProjectComponent.java
+++ b/src/main/java/io/binx/cfnlint/plugin/CheckProjectComponent.java
@@ -73,7 +73,7 @@ public class CheckProjectComponent implements com.intellij.openapi.components.Pr
     }
 
     private void validationFailed(String msg) {
-        NotificationListener notificationListener = (notification, event) -> new SettingsPage(project, settings).showSettings();
+        NotificationListener notificationListener = (notification, event) -> new SettingsPage(project).showSettings();
         String errorMessage = msg + Bundle.message("settings.fix");
         showInfoNotification(errorMessage, NotificationType.WARNING, notificationListener);
         LOG.debug(msg);

--- a/src/main/java/io/binx/cfnlint/plugin/settings/Settings.java
+++ b/src/main/java/io/binx/cfnlint/plugin/settings/Settings.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
@@ -23,7 +24,7 @@ public class Settings implements PersistentStateComponent<Settings> {
     }
 
     @Override
-    public void loadState(Settings state) {
+    public void loadState(@NotNull Settings state) {
         XmlSerializerUtil.copyBean(state, this);
     }
 

--- a/src/main/java/io/binx/cfnlint/plugin/settings/SettingsPage.java
+++ b/src/main/java/io/binx/cfnlint/plugin/settings/SettingsPage.java
@@ -39,9 +39,9 @@ public class SettingsPage implements Configurable {
     private JLabel exeLabel;
     private TextFieldWithHistoryWithBrowseButton exeField;
 
-    public SettingsPage(@NotNull final Project project, @NotNull Settings settings) {
+    public SettingsPage(@NotNull final Project project) {
         this.project = project;
-        this.settings = settings;
+        this.settings = project.getService(Settings.class);
         initField();
     }
 


### PR DESCRIPTION
Pull request #19 don't really brings 2021.1 support.

The plugin loads but the are exceptions:
```
com.intellij.diagnostic.PluginException: Cannot create class io.binx.cfnlint.plugin.settings.SettingsPage (classloader=PluginClassLoader(plugin=PluginDescriptor(name=cfn-lint, id=io.binx.cfnlint.plugin, descriptorPath=plugin.xml, path=~/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/211.6693.111.plugins/cfn-lint-plugin, version=0.1.19, package=null), packagePrefix=null, instanceId=26, state=active))
Caused by: java.lang.IllegalArgumentException: wrong number of arguments
...
```

This pull request makes the plugin works in 2021.1.