### PR TITLE
feat: 2022.1 IntelliJ support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.3.0'
+    id 'org.jetbrains.intellij' version '1.5.3'
     id 'io.freefair.git-version' version '5.3.3.3'
 }
 
@@ -19,11 +19,12 @@ dependencies {
 }
 
 intellij {
-    version.set('2021.3')
+    version.set('2022.1')
 }
 
 patchPluginXml {
     changeNotes = """
+       <p>0.1.22 fixed IntelliJ 2022.1 support by Michael Brewer</p>
        <p>0.1.22 fixed IntelliJ 2021.3 support by Philippe Jandot</p>
        <p>0.1.21 fixed IntelliJ 2021.2 support by Michael Brewer</p>
        <p>0.1.20 fixed IntelliJ 2021.1 support by Philippe Jandot</p>


### PR DESCRIPTION
Changes:
- Bump org.jetbrains.intellij to 1.5.3
- Set version to 2022.1