### PR TITLE
documenting AWSTemplateFormatVersion requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Intellij plugin for validating AWS CloudFormation templates using cfn-lint
 
+Templates must include [AWSTemplateFormatVersion](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html)
 
 ### Install plugin
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Intellij plugin for validating AWS CloudFormation templates using cfn-lint
 
-Templates must include [AWSTemplateFormatVersion](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html)
+Templates must include [`AWSTemplateFormatVersion`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html)
 
 ### Install plugin
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
     <vendor email="info@binx.io" url="https://github.com/binxio/">binx.io</vendor>
 
     <description><![CDATA[
-    Analyze CloudFormation templates with cfn-lint
+    Analyze CloudFormation templates with cfn-lint. Templates must include AWSTemplateFormatVersion
     ]]></description>
 
     <change-notes><![CDATA[


### PR DESCRIPTION
[`AWSTemplateFormatVersion`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html) is optional in CloudFormation itself

https://github.com/binxio/cfn-lint-plugin/commit/f54095c7a61c2a1e63cf34016057921dd165da11