### PR TITLE
include informational checks by default

### DIFF
--- a/src/main/java/io/binx/cfnlint/plugin/utils/CheckRunner.java
+++ b/src/main/java/io/binx/cfnlint/plugin/utils/CheckRunner.java
@@ -36,11 +36,11 @@ public final class CheckRunner {
             File path = new File(new File(cwd), file);
             GeneralCommandLine commandLine = createCommandLine(exe, cwd);
             if (content == null) {
-                commandLine = commandLine.withParameters("-f", "json", "-t", file);
+                commandLine = commandLine.withParameters("-f", "json", "--include-checks", "I", "-t", file);
             } else {
                 commandLine = ((CommandLineWithInput) commandLine)
                         .withInput(content)
-                        .withParameters("-f", "json", "-t", "-");
+                        .withParameters("-f", "json", "--include-checks", "I", "-t", "-");
             }
             ProcessOutput out = execute(commandLine);
             try {


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-lint/#info-rules

As with https://github.com/aws-cloudformation/cfn-lint-visual-studio-code/pull/223, editors seem like a great place to start surfacing informational checks by default since they are easily ignored and the exit code doesn't really matter

---

Don't have the domain knowledge to personally test these changes, but informational severity looks already mapped here:
https://github.com/binxio/cfn-lint-plugin/blob/7fca2c4989e987698a4d9d3a4fc1865dbcc59109/src/main/java/io/binx/cfnlint/plugin/CheckExternalAnnotator.java#L97-L108